### PR TITLE
Prevent bundling of .env and document secure handling of API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ DocPilot is a Flutter application designed to assist healthcare providers in rec
    DEEPGRAM_API_KEY=your_deepgram_api_key
    GEMINI_API_KEY=your_gemini_api_key
    ```
+   
+    Important: Do NOT commit your `.env` file. It contains sensitive API keys.
+    Use `.env.example` as a template and add `.env` to your `.gitignore`.
+    For CI or shared environments, store secrets in your CI provider's secret
+    management system or environment variables instead of committing them.
 
 4. Run the app:
    ```bash

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,8 +55,7 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-  assets:
-    - .env
+  # No assets to bundle by default. Keep secrets out of assets.
 
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
@@ -93,3 +92,4 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/to/font-from-package
+


### PR DESCRIPTION
This PR removes `.env` from being **bundled** into the app (by removing it from **flutter.assets** in **pubspec.yaml**), confirms that `.env` is listed in **.gitignore,** and adds a note to the README warning contributors not to commit API keys.

-  pubspec.yaml updated  
-  README.md updated  
-  .gitignore already included `.env` (confirmed)

This helps reduce the risk of leaking secrets and improves onboarding for new contributors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security guidance for managing API keys and environment variables, recommending `.env.example` usage and preventing `.env` commits through `.gitignore`.

* **Chores**
  * Updated configuration to exclude secret files from asset bundling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->