### PR TITLE
feat: dynamic model selection for Gemini Flash, Pro, and Gemma

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -314,14 +314,21 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> with SingleTi
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                // App header
-                const Text(
-                  'DocPilot',
-                  style: TextStyle(
-                    fontSize: 28,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white,
-                  ),
+                // App header row with model picker
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text(
+                      'DocPilot',
+                      style: TextStyle(
+                        fontSize: 28,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                      ),
+                    ),
+                    _buildModelPicker(),
+                  ],
                 ),
                 const SizedBox(height: 8),
                 Text(
@@ -330,7 +337,7 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> with SingleTi
                       : _isTranscribing
                       ? 'Transcribing your voice...'
                       : _isProcessing
-                      ? 'Processing with Gemini...'
+                      ? 'Processing with ${_chatbotService.selectedModel.displayName}...'
                       : 'Tap the mic to begin',
                   style: const TextStyle(
                     fontSize: 16,
@@ -499,6 +506,44 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> with SingleTi
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildModelPicker() {
+    return PopupMenuButton<GeminiModel>(
+      initialValue: _chatbotService.selectedModel,
+      tooltip: 'Select AI model',
+      icon: const Icon(Icons.tune, color: Colors.white70, size: 22),
+      color: Colors.deepPurple.shade700,
+      onSelected: (model) {
+        setState(() {
+          _chatbotService.selectedModel = model;
+        });
+      },
+      itemBuilder: (_) => GeminiModel.values.map((model) {
+        return PopupMenuItem<GeminiModel>(
+          value: model,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                model.displayName,
+                style: TextStyle(
+                  color: Colors.white,
+                  fontWeight: _chatbotService.selectedModel == model
+                      ? FontWeight.bold
+                      : FontWeight.normal,
+                ),
+              ),
+              Text(
+                model.description,
+                style: const TextStyle(fontSize: 11, color: Colors.white60),
+              ),
+            ],
+          ),
+        );
+      }).toList(),
     );
   }
 

--- a/lib/services/chatbot_service.dart
+++ b/lib/services/chatbot_service.dart
@@ -3,45 +3,94 @@ import 'dart:developer' as developer;
 import 'package:http/http.dart' as http;
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
+/// Supported Gemini/Gemma models via the Gemini API.
+enum GeminiModel {
+  flash('gemini-2.0-flash', 'Gemini 2.0 Flash', 'Fast responses, good for most tasks'),
+  pro('gemini-1.5-pro', 'Gemini 1.5 Pro', 'Higher accuracy for complex reasoning'),
+  gemma('gemma-3-27b-it', 'Gemma 3 27B', 'Open-weight model, efficient summarisation');
+
+  final String modelId;
+  final String displayName;
+  final String description;
+
+  const GeminiModel(this.modelId, this.displayName, this.description);
+}
+
 class ChatbotService {
-  // Get API key from .env file
-  final String apiKey = dotenv.env['GEMINI_API_KEY'] ?? '';
+  final String _apiKey = dotenv.env['GEMINI_API_KEY'] ?? '';
 
-  // Get a response from Gemini based on a prompt
+  GeminiModel selectedModel;
+
+  ChatbotService({this.selectedModel = GeminiModel.flash});
+
+  bool get hasValidApiKey {
+    final trimmed = _apiKey.trim();
+    if (trimmed.isEmpty) return false;
+    final lower = trimmed.toLowerCase();
+    return !lower.contains('your_gemini_api_key_here') &&
+        !lower.contains('replace_with') &&
+        !lower.contains('example') &&
+        !lower.contains('dummy');
+  }
+
   Future<String> getGeminiResponse(String prompt) async {
-    print('\n=== GEMINI PROMPT ===');
-    print(prompt);
+    if (!hasValidApiKey) {
+      return 'Error: GEMINI_API_KEY is missing. Add it to your .env file.';
+    }
 
-    final url = Uri.parse('https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=$apiKey');
+    developer.log(
+      'Sending prompt to ${selectedModel.displayName}',
+      name: 'ChatbotService',
+    );
+
+    final url = Uri.parse(
+      'https://generativelanguage.googleapis.com/v1beta/models/${selectedModel.modelId}:generateContent?key=$_apiKey',
+    );
 
     try {
       final response = await http.post(
         url,
         headers: {'Content-Type': 'application/json'},
         body: jsonEncode({
-          "contents": [{"parts": [{"text": prompt}]}],
-          "generationConfig": {
-            "temperature": 0.7,
-            "maxOutputTokens": 1024
-          }
+          'contents': [
+            {
+              'parts': [
+                {'text': prompt}
+              ]
+            }
+          ],
+          'generationConfig': {
+            'temperature': 0.7,
+            'maxOutputTokens': 1024,
+          },
         }),
-      );
+      ).timeout(const Duration(seconds: 30));
 
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);
-        final result = data['candidates'][0]['content']['parts'][0]['text'];
-
-        print('\n=== GEMINI RESPONSE ===');
-        print(result);
-
-        return result;
+        final candidates = data['candidates'];
+        if (candidates is List && candidates.isNotEmpty) {
+          final text = candidates[0]['content']?['parts']?[0]?['text'];
+          if (text is String && text.trim().isNotEmpty) {
+            developer.log('Response received from ${selectedModel.displayName}', name: 'ChatbotService');
+            return text;
+          }
+        }
+        return 'Error: Unexpected response format from ${selectedModel.displayName}.';
       } else {
-        print('API Error: ${response.statusCode}');
-        return "Error: Could not generate response. Status code: ${response.statusCode}";
+        String message = 'Error: ${selectedModel.displayName} request failed (status ${response.statusCode}).';
+        try {
+          final apiError = jsonDecode(response.body)['error']?['message'];
+          if (apiError is String && apiError.trim().isNotEmpty) {
+            message = 'Error: $apiError';
+          }
+        } catch (_) {}
+        developer.log('API error ${response.statusCode}: ${response.body}', name: 'ChatbotService');
+        return message;
       }
     } catch (e) {
-      print('Exception: $e');
-      return "Error: Could not connect to API: $e";
+      developer.log('Request failed: $e', name: 'ChatbotService', error: e);
+      return 'Error: Could not reach ${selectedModel.displayName}. Check your connection and try again.';
     }
   }
 }


### PR DESCRIPTION
Closes #8

## Problem

`ChatbotService` had the Gemini model hardcoded as `gemini-2.0-flash`. Users with more complex medical notes had no way to use a more capable model, and there was no path to try Gemma's open-weight models.

## Changes

### `lib/services/chatbot_service.dart`

- Added a `GeminiModel` enum with three entries:

  | Value | Model ID | Use case |
  |---|---|---|
  | `flash` (default) | `gemini-2.0-flash` | Fast responses, good for most tasks |
  | `pro` | `gemini-1.5-pro` | Higher accuracy for complex reasoning |
  | `gemma` | `gemma-3-27b-it` | Open-weight, efficient summarisation |

  Each entry carries a `modelId` (used in the API URL), a `displayName` (shown in the UI), and a short `description` (shown as a subtitle in the picker).

- `ChatbotService` now holds a `selectedModel` field (defaults to `flash`) that is used when building the API URL. It can be changed at any time between recordings.

- Added `hasValidApiKey` guard and structured Gemini error extraction while staying independently reviewable from #13.

### `lib/main.dart`

- Added a `PopupMenuButton` (tune icon) to the right of the "DocPilot" title. Tapping it shows the three models with their descriptions. Selecting one updates `_chatbotService.selectedModel` via `setState`.
- The status text during processing now reads "Processing with [Model Name]..." instead of the generic "Processing with Gemini...".

## How it works

The model picker is in the app bar area so it is always accessible. The selected model persists for the lifetime of the app session and is used for all Gemini calls (summary and prescription) until changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model selection dropdown in the app header
  * Support for multiple AI models: Gemini 2.0 Flash, Gemini 1.5 Pro, and Gemma 3 27B

* **Improvements**
  * Enhanced API key validation and error handling
  * Processing status messages now display the currently selected model
  * Added request timeout for improved reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->