### PR TITLE
refactor: extract Deepgram API call into TranscriptionService

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,17 +1,14 @@
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
 import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:record/record.dart';
-import 'package:http/http.dart' as http;
 import 'package:permission_handler/permission_handler.dart';
 import 'dart:developer' as developer;
-import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import 'services/chatbot_service.dart';
+import 'services/transcription_service.dart';
 import 'screens/transcription_detail_screen.dart';
 import 'screens/summary_screen.dart';
 import 'screens/prescription_screen.dart';
@@ -59,8 +56,9 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> with SingleTi
   String _summaryContent = '';
   String _prescriptionContent = '';
 
-  // Chatbot service
+  // Services
   final ChatbotService _chatbotService = ChatbotService();
+  final TranscriptionService _transcriptionService = TranscriptionService();
 
   // For waveform animation
   late AnimationController _animationController;
@@ -185,67 +183,31 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> with SingleTi
   }
 
   Future<void> _transcribeAudio() async {
-    try {
-      final apiKey = dotenv.env['DEEPGRAM_API_KEY'] ?? '';
-      final uri = Uri.parse('https://api.deepgram.com/v1/listen?model=nova-2');
+    final result = await _transcriptionService.transcribe(_recordingPath);
 
-      final file = File(_recordingPath);
-      if (!await file.exists()) {
-        setState(() {
-          _isTranscribing = false;
-          _transcription = 'Recording file not found';
-        });
-        return;
-      }
-
-      final bytes = await file.readAsBytes();
-      final response = await http.post(
-        uri,
-        headers: {
-          'Authorization': 'Token $apiKey',
-          'Content-Type': 'audio/m4a',
-        },
-        body: bytes,
-      );
-
-      if (response.statusCode == 200) {
-        final decodedResponse = json.decode(response.body);
-        final result = decodedResponse['results']['channels'][0]['alternatives'][0]['transcript'];
-
-        setState(() {
-          _isTranscribing = false;
-          _transcription = result.isNotEmpty ? result : 'No speech detected';
-          _formattedTranscription = _transcription; // Store raw transcription directly
-          _isProcessing = true;
-        });
-
-        // Print the transcription to console
-        print('\n============ TRANSCRIPTION RESULT ============');
-        print(_transcription);
-        print('=============================================');
-
-        // Send to Gemini for processing if we have a valid transcription
-        if (_transcription.isNotEmpty && _transcription != 'No speech detected') {
-          await _processWithGemini(_transcription);
-        } else {
-          setState(() {
-            _isProcessing = false;
-          });
-        }
-      } else {
-        setState(() {
-          _isTranscribing = false;
-          _transcription = 'Transcription failed';
-          _isProcessing = false;
-        });
-      }
-    } catch (e) {
+    if (!result.isSuccess) {
       setState(() {
         _isTranscribing = false;
-        _transcription = 'Error during transcription';
         _isProcessing = false;
+        _transcription = result.error!;
       });
-      print('Error: $e');
+      return;
+    }
+
+    final text = result.transcript!;
+    final hasContent = text.isNotEmpty;
+
+    setState(() {
+      _isTranscribing = false;
+      _transcription = hasContent ? text : 'No speech detected';
+      _formattedTranscription = _transcription;
+      _isProcessing = hasContent;
+    });
+
+    developer.log('Transcription: $_transcription', name: 'TranscriptionScreen');
+
+    if (hasContent) {
+      await _processWithGemini(text);
     }
   }
 

--- a/lib/services/transcription_service.dart
+++ b/lib/services/transcription_service.dart
@@ -1,0 +1,103 @@
+import 'dart:io';
+import 'dart:convert';
+import 'dart:developer' as developer;
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+/// Result returned by [TranscriptionService.transcribe].
+///
+/// On success [transcript] contains the recognised text and [error] is null.
+/// On failure [error] describes what went wrong and [transcript] is null.
+class TranscriptionResult {
+  final String? transcript;
+  final String? error;
+
+  const TranscriptionResult.success(String this.transcript) : error = null;
+  const TranscriptionResult.failure(String this.error) : transcript = null;
+
+  bool get isSuccess => transcript != null;
+}
+
+/// Handles audio transcription via the Deepgram Nova-2 API.
+///
+/// Separating this from the UI layer makes the Deepgram integration
+/// independently testable and keeps [TranscriptionScreen] free of HTTP logic.
+class TranscriptionService {
+  final String _apiKey;
+
+  TranscriptionService() : _apiKey = dotenv.env['DEEPGRAM_API_KEY'] ?? '';
+
+  bool get hasValidApiKey {
+    final trimmed = _apiKey.trim();
+    if (trimmed.isEmpty) return false;
+    final lower = trimmed.toLowerCase();
+    return !lower.contains('your_deepgram_api_key_here') &&
+        !lower.contains('replace_with') &&
+        !lower.contains('example') &&
+        !lower.contains('dummy');
+  }
+
+  /// Transcribes the audio file at [filePath] using Deepgram's Nova-2 model.
+  ///
+  /// Returns a [TranscriptionResult] — callers should check [TranscriptionResult.isSuccess]
+  /// before using the transcript.
+  Future<TranscriptionResult> transcribe(String filePath) async {
+    if (!hasValidApiKey) {
+      return const TranscriptionResult.failure(
+        'DEEPGRAM_API_KEY is missing or still a placeholder. Add a real key to .env.',
+      );
+    }
+
+    final file = File(filePath);
+    if (!await file.exists()) {
+      return const TranscriptionResult.failure('Recording file not found.');
+    }
+
+    final uri = Uri.parse('https://api.deepgram.com/v1/listen?model=nova-2');
+
+    try {
+      final bytes = await file.readAsBytes();
+      final response = await http.post(
+        uri,
+        headers: {
+          'Authorization': 'Token $_apiKey',
+          'Content-Type': 'audio/m4a',
+        },
+        body: bytes,
+      ).timeout(const Duration(seconds: 60));
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        final text = data['results']?['channels']?[0]?['alternatives']?[0]?['transcript'] as String?;
+
+        if (text == null || text.trim().isEmpty) {
+          developer.log('Deepgram returned empty transcript', name: 'TranscriptionService');
+          return const TranscriptionResult.success('');
+        }
+
+        developer.log('Transcription succeeded (${text.length} chars)', name: 'TranscriptionService');
+        return TranscriptionResult.success(text.trim());
+      } else {
+        String message = 'Transcription failed (status ${response.statusCode}).';
+        try {
+          final body = jsonDecode(response.body);
+          final detail = body['err_msg'] ?? body['error'] ?? body['message'];
+          if (detail is String && detail.trim().isNotEmpty) {
+            message = 'Transcription failed: $detail';
+          }
+        } catch (_) {}
+
+        developer.log(
+          'Deepgram error ${response.statusCode}: ${response.body}',
+          name: 'TranscriptionService',
+        );
+        return TranscriptionResult.failure(message);
+      }
+    } catch (e) {
+      developer.log('Transcription request failed: $e', name: 'TranscriptionService', error: e);
+      return TranscriptionResult.failure(
+        'Could not reach Deepgram. Check your connection and try again.',
+      );
+    }
+  }
+}


### PR DESCRIPTION
Closes #11

## Problem

As noted in #11, `main.dart` was doing too many things at once — managing UI state, handling audio recording, making raw Deepgram HTTP requests, and orchestrating Gemini processing, all in a single 500-line file. This made the Deepgram logic untestable in isolation and harder to change without touching the UI.

## Changes

### `lib/services/transcription_service.dart` (new file)

`TranscriptionService` takes sole ownership of the Deepgram integration:

- `transcribe(filePath)` handles reading the file, POSTing to the Deepgram Nova-2 endpoint, parsing the response, and mapping errors to human-readable messages.
- Returns a `TranscriptionResult` value object (`success` / `failure`) so the caller never has to inspect HTTP status codes.
- `hasValidApiKey` rejects empty and placeholder key values before any network call is made.
- Timeout set to 60 seconds to handle large audio files.
- All logging goes through `developer.log()` with the `TranscriptionService` tag.

### `lib/main.dart`

- `_TranscriptionScreenState` now instantiates `TranscriptionService` alongside `ChatbotService`.
- `_transcribeAudio()` is reduced from ~50 lines of HTTP boilerplate to a single `await _transcriptionService.transcribe(_recordingPath)` call followed by straightforward state updates based on `result.isSuccess`.
- Removed now-unused imports: `dart:convert`, `dart:io`, `package:http/http.dart`, `package:flutter_markdown/flutter_markdown.dart`.

## What was intentionally left for follow-up

The audio recording logic (`_startRecording`, `_stopRecording`, `AudioRecorder`) still lives in the widget. Extracting that is a larger change — a `RecordingService` would be a natural next step, but keeping this PR focused makes it easier to review.
