### PR TITLE
fix: replace deprecated withOpacity() with withValues(alpha:)

### DIFF
--- a/lib/features/transcription/presentation/transcription_screen.dart
+++ b/lib/features/transcription/presentation/transcription_screen.dart
@@ -58,7 +58,7 @@ class TranscriptionScreen extends StatelessWidget {
                           decoration: BoxDecoration(
                             color: controller.isRecording
                                 ? HSLColor.fromAHSL(1.0, (280 + index * 2) % 360, 0.8, 0.7 + value * 0.2).toColor()
-                                : Colors.white.withOpacity(0.5),
+                                : Colors.white.withValues(alpha: 0.5),
                             borderRadius: BorderRadius.circular(5),
                           ),
                         );
@@ -80,7 +80,7 @@ class TranscriptionScreen extends StatelessWidget {
                         color: controller.isRecording ? Colors.red : Colors.white,
                         boxShadow: [
                           BoxShadow(
-                            color: (controller.isRecording ? Colors.red : Colors.white).withOpacity(0.3),
+                            color: (controller.isRecording ? Colors.red : Colors.white).withValues(alpha: 0.3),
                             spreadRadius: 8,
                             blurRadius: 20,
                           ),
@@ -199,8 +199,8 @@ class TranscriptionScreen extends StatelessWidget {
           padding: const EdgeInsets.symmetric(vertical: 16),
           backgroundColor: Colors.white,
           foregroundColor: Colors.deepPurple,
-          disabledBackgroundColor: Colors.white.withOpacity(0.3),
-          disabledForegroundColor: Colors.white.withOpacity(0.5),
+          disabledBackgroundColor: Colors.white.withValues(alpha: 0.3),
+          disabledForegroundColor: Colors.white.withValues(alpha: 0.5),
           elevation: isEnabled ? 4 : 0,
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         ),

--- a/lib/screens/transcription_detail_screen.dart
+++ b/lib/screens/transcription_detail_screen.dart
@@ -86,10 +86,10 @@ class TranscriptionDetailScreen extends StatelessWidget {
         margin: const EdgeInsets.only(bottom: 12),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
-          color: Colors.grey.withOpacity(0.1),
+          color: Colors.grey.withValues(alpha: 0.1),
           borderRadius: BorderRadius.circular(12),
           border: Border.all(
-            color: Colors.grey.withOpacity(0.3),
+            color: Colors.grey.withValues(alpha: 0.3),
             width: 1,
           ),
         ),


### PR DESCRIPTION
Fixes #39

## Summary

Replace all `Color.withOpacity(x)` calls with `Color.withValues(alpha: x)` across the codebase. The `withOpacity()` method is deprecated as of Flutter 3.27 in favor of `withValues()` which provides proper color space handling.

## Changes

| File | Occurrences Fixed |
|------|:-:|
| `lib/features/transcription/presentation/transcription_screen.dart` | 4 |
| `lib/screens/transcription_detail_screen.dart` | 2 |

## Example

```diff
- Colors.white.withOpacity(0.5)
+ Colors.white.withValues(alpha: 0.5)
```

## References
- [Flutter Color.withOpacity deprecation](https://api.flutter.dev/flutter/dart-ui/Color/withOpacity.html)