### PR TITLE
fix: replace broken default counter test with DocPilot smoke tests

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,9 +1,7 @@
-// This is a basic Flutter widget test.
+// Basic smoke test for DocPilot app.
 //
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
+// Verifies that the app renders its core UI elements without crashing.
+// This replaces the default Flutter counter test which was invalid for DocPilot.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -11,20 +9,29 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:doc_pilot_new_app_gradel_fix/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('DocPilot app renders without crashing', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    // Verify the app title is displayed
+    expect(find.text('DocPilot'), findsWidgets);
+  });
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+  testWidgets('DocPilot app shows microphone button', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify the microphone icon is present on the main screen
+    expect(find.byIcon(Icons.mic), findsOneWidget);
+  });
+
+  testWidgets('DocPilot app shows navigation buttons', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+
+    // Verify the three navigation buttons exist
+    expect(find.text('Transcription'), findsOneWidget);
+    expect(find.text('Summary'), findsOneWidget);
+    expect(find.text('Prescription'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Fixes #40

## Summary

The existing `test/widget_test.dart` is the default Flutter counter app test from `flutter create`. It tests for a counter widget (`find.text('0')`, `find.byIcon(Icons.add)`) that does **not exist** in DocPilot, causing the test to always fail.

## Changes

Replaced with three basic smoke tests for DocPilot:

| Test | Verifies |
|------|----------|
| `DocPilot app renders without crashing` | App starts and shows 'DocPilot' title |
| `DocPilot app shows microphone button` | Mic icon is present on main screen |
| `DocPilot app shows navigation buttons` | Transcription, Summary, and Prescription buttons exist |

## Before

```dart
// Tests for a counter app that doesn't exist in DocPilot
expect(find.text('0'), findsOneWidget);        // ❌ Always fails
await tester.tap(find.byIcon(Icons.add));      // ❌ No such icon
```

## After

```dart
// Tests for actual DocPilot UI elements
expect(find.text('DocPilot'), findsWidgets);   // ✅ App title
expect(find.byIcon(Icons.mic), findsOneWidget); // ✅ Mic button
expect(find.text('Transcription'), findsOneWidget); // ✅ Nav button
```