### PR TITLE
security: add critical .gitignore entries for API keys and signing credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,17 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Android release signing (MUST NOT commit)
+android/key.properties
+*.jks
+*.keystore
+
+# Firebase credentials (MUST NOT commit)
+android/app/google-services.json
+ios/Runner/GoogleService-Info.plist
+
+# API keys and secrets
+.env.local
+.env.production
+.secrets/


### PR DESCRIPTION
Fixes #41

## Summary

The current `.gitignore` lacks protection against accidentally committing sensitive files. Any contributor setting up Firebase or configuring release signing could push API keys or credentials to this public repo.

## Changes

Added the following exclusions to `.gitignore`:

| Entry | Purpose |
|-------|---------|
| `android/key.properties` | Android release signing passwords |
| `*.jks` / `*.keystore` | Android signing keystores |
| `android/app/google-services.json` | Firebase API keys (Android) |
| `ios/Runner/GoogleService-Info.plist` | Firebase API keys (iOS) |
| `.env.local` / `.env.production` | Production API keys |
| `.secrets/` | General secrets directory |

## Why This Matters

`.env` is already ignored, but `.env.local` and `.env.production` are not. Firebase config files contain API keys and project IDs that should remain private. Android signing keystores contain cryptographic keys used to sign release builds.