### PR TITLE
fix: remove unnecessary 3-second delay in prescription generation

### DIFF
--- a/lib/features/transcription/data/gemini_service.dart
+++ b/lib/features/transcription/data/gemini_service.dart
@@ -10,7 +10,6 @@ class GeminiService {
   }
 
   Future<String> generatePrescription(String transcription) async {
-    await Future.delayed(const Duration(seconds: 3));
     return await _chatbotService.getGeminiResponse(
       "Generate a prescription based on the conversation in this transcription: $transcription",
     );


### PR DESCRIPTION
Fixes #42

## Summary

The `generatePrescription()` method in `GeminiService` has a hardcoded `Future.delayed(const Duration(seconds: 3))` before the API call, adding 3 seconds of unnecessary wait time to every prescription generation.

The `generateSummary()` method does **not** have this delay, suggesting it was unintentional or leftover from debugging.

## Change

```diff
  Future<String> generatePrescription(String transcription) async {
-   await Future.delayed(const Duration(seconds: 3));
    return await _chatbotService.getGeminiResponse(
      "Generate a prescription...",
    );
  }
```

## Impact

Prescription generation is now ~3 seconds faster for every user request.