### PR TITLE
fix: remove unnecessary 3-second delay in prescription generation

### DIFF
--- a/lib/features/transcription/data/gemini_service.dart
+++ b/lib/features/transcription/data/gemini_service.dart
@@ -10,7 +10,6 @@ class GeminiService {
   }
 
   Future<String> generatePrescription(String transcription) async {
-    await Future.delayed(const Duration(seconds: 3));
     return await _chatbotService.getGeminiResponse(
       "Generate a prescription based on the conversation in this transcription: $transcription",
     );


### PR DESCRIPTION
## Description

This PR removes an arbitrary 3-second delay that was blocking the prescription generation flow. The delay was added via `Future.delayed(const Duration(seconds: 3))` in the `generatePrescription()` method but wasn't present in the similar `generateSummary()` method.

## Changes Made

- Removed the hardcoded 3-second delay from `lib/features/transcription/data/gemini_service.dart`
- Prescription generation now responds immediately after the API call completes

## Impact

Before:
- Users waited 3 extra seconds for every prescription generation
- On slow networks, this made the app feel significantly sluggish

After:
- Prescription generation is 3 seconds faster
- Response time is now consistent with summary generation
- Better user experience overall

## Testing

- Verified that prescription generation still works correctly
- Confirmed no breaking changes to the API integration
- Tested on Android emulator with various transcriptions

## Related Issues

Fixes #42

---

**Note:** If the delay was intentional for rate limiting purposes, this should be handled with proper retry logic or documented in the code. Currently, it appears to be unintentional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prescription generation response time by eliminating an unnecessary delay, allowing faster results delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->